### PR TITLE
Add captions

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -33,7 +33,16 @@ export default class LiteGallery extends Plugin {
 			
 			// Split the source into lines, remove brackets and whitespace, and filter out empty lines
 			const image_list = source.split('\n')
-				.map((line) => line.replace(/!?\[\[/, "").replace("]]", "").trim())
+				.map((line) => {
+					line = line.trim();
+					// Check for Markdown image syntax: ![alt](path)
+					const markdown_match = line.match(/!\[.*?\]\((.+?)\)/);
+					if (markdown_match) {
+						return markdown_match[1].trim();
+					}
+					// Check for wiki-link style: [[image]] or ![[image]]
+					return line.replace(/!?\[\[/, "").replace("]]", "").trim();
+				})
 				.filter((line) => line)
 				.map((image) => {
 					// If image is a URL (http/https) or a local file path, return it as is

--- a/main.ts
+++ b/main.ts
@@ -36,18 +36,28 @@ export default class LiteGallery extends Plugin {
 				.map((line) => {
 					line = line.trim();
 					// Check for Markdown image syntax: ![alt](path)
-					const markdown_match = line.match(/!\[.*?\]\((.+?)\)/);
+					const markdown_match = line.match(/!\[(.*)?\]\((.+?)\)/);
 					if (markdown_match) {
-						return markdown_match[1].trim();
+						return {
+							caption: markdown_match[1]?.trim() || '',
+							path: markdown_match[2].trim()
+						};
 					}
 					// Check for wiki-link style: [[image]] or ![[image]]
-					return line.replace(/!?\[\[/, "").replace("]]", "").trim();
+					const wiki_path = line.replace(/!?\[\[/, "").replace("]]", "").trim();
+					return {
+						caption: '',
+						path: wiki_path
+					};
 				})
-				.filter((line) => line)
-				.map((image) => {
+				.filter((line) => line.path)
+				.map((image_data) => {
 					// If image is a URL (http/https) or a local file path, return it as is
-					if (image.match(/^(http|https):\/\//)) {
-						return image
+					if (image_data.path.match(/^(http|https):\/\//)) {
+						return {
+							caption: image_data.caption,
+							path: image_data.path
+						};
 					}
 					// Check if the image exists in any of the folders specified in settings and return the path if it does, otherwise return undefined
 					let image_exists = false
@@ -55,7 +65,7 @@ export default class LiteGallery extends Plugin {
 					let path_options = this.settings.image_folders.map((folder) => { 
 						return `${(folder.slice(-1) == "/") ? 
 							(folder == "/" ? "" : folder) : // If folder doesn't need a trailing slash, don't add it (if it's root dir should just be empty string)
-							`${folder}/`}${image}` // If folder needs a trailing slash, add it
+							`${folder}/`}${image_data.path}` // If folder needs a trailing slash, add it
 					})
 					for (const test_path of path_options) {
 						const file = this.app.vault.getAbstractFileByPath(test_path);
@@ -66,11 +76,14 @@ export default class LiteGallery extends Plugin {
 						}
 					}
 					if (image_path == undefined) {
-						new Notice(`LiteGallery: Image not found: ${image}`)
+						new Notice(`LiteGallery: Image not found: ${image_data.path}`)
 					}
-					return image_path
+					return image_path ? {
+						caption: image_data.caption,
+						path: image_path
+					} : undefined;
 				}
-			).filter((image_path) => image_path !== undefined) as string[]
+			).filter((image_data) => image_data !== undefined) as Array<{caption: string, path: string}>
 			console.log(image_list)
 			// Create the lightbox container
 			const lightbox_container = document.body.createEl('div', {
@@ -104,15 +117,22 @@ export default class LiteGallery extends Plugin {
 
 				// Create the active image element and set its source to the first image in the list
 				const active_image = active_image_container_inner.createEl('img')
-				active_image.src = image_list[active_slide]
+				active_image.src = image_list[active_slide].path
 
 				active_image.onclick = () => {
 					lightbox_container.removeClass('hidden')
-					lightbox_image.src = image_list[active_slide]
+					lightbox_image.src = image_list[active_slide].path
+					lightbox_caption.textContent = image_list[active_slide].caption
 				}
 				active_image.onerror = function() {
 					this.src='https://raw.githubusercontent.com/jpoles1/obsidian-litegal/eb0e30b2709a3081dd8d32ef4371367b95694881/404notfound.jpg'
 				}
+
+				// Create the caption element for the active image
+				const active_caption = active_image_container.createEl('div', {
+					cls: 'litegal-caption',
+					text: image_list[active_slide].caption
+				})
 				
 				// Create the left arrow element and handle click event to navigate to the previous image
 				const larrow = active_image_container.createEl('div', {
@@ -121,7 +141,8 @@ export default class LiteGallery extends Plugin {
 				})
 				larrow.onclick = () => {
 					active_slide = (active_slide - 1 + image_list.length) % image_list.length
-					active_image.src = image_list[active_slide]
+					active_image.src = image_list[active_slide].path
+					active_caption.textContent = image_list[active_slide].caption
 				}
 
 				// Create the right arrow element and handle click event to navigate to the next image
@@ -131,7 +152,8 @@ export default class LiteGallery extends Plugin {
 				})
 				rarrow.onclick = () => {
 					active_slide = (active_slide + 1) % image_list.length
-					active_image.src = image_list[active_slide]
+					active_image.src = image_list[active_slide].path
+					active_caption.textContent = image_list[active_slide].caption
 				}
 
 				// Create the container for the preview section
@@ -172,12 +194,12 @@ export default class LiteGallery extends Plugin {
 				}, 10)
 
 				// Iterate over the image list and create preview elements for each image
-				image_list.forEach(async (image_path: string, i) => {				
+				image_list.forEach(async (image_data: {caption: string, path: string}, i) => {				
 					// Create the preview image element and set its source to the corresponding image in the list
 					const preview_elem = preview_container.createEl('img', {
 						cls: 'litegal-preview-img'
 					})
-					preview_elem.src = image_path
+					preview_elem.src = image_data.path
 					preview_elem.onerror = function() {
 						this.src='https://raw.githubusercontent.com/jpoles1/obsidian-litegal/eb0e30b2709a3081dd8d32ef4371367b95694881/404notfound.jpg'
 					}
@@ -185,7 +207,8 @@ export default class LiteGallery extends Plugin {
 					// Handle click event to set the active slide and update the active image
 					preview_elem.onclick = () => {
 						active_slide = i
-						active_image.src = `${image_list[active_slide]}`
+						active_image.src = image_list[active_slide].path
+						active_caption.textContent = image_list[active_slide].caption
 					}					
 					// Append the preview element to the preview container
 				})
@@ -199,8 +222,10 @@ export default class LiteGallery extends Plugin {
 				})
 				lightbox_larrow.onclick = () => {
 					active_slide = (active_slide - 1 + image_list.length) % image_list.length
-					lightbox_image.src = image_list[active_slide]
-					active_image.src = image_list[active_slide]
+					lightbox_image.src = image_list[active_slide].path
+					lightbox_caption.textContent = image_list[active_slide].caption
+					active_image.src = image_list[active_slide].path
+					active_caption.textContent = image_list[active_slide].caption
 				}
 
 				// Create the right arrow element for the lightbox and handle click event to navigate to the next
@@ -210,8 +235,10 @@ export default class LiteGallery extends Plugin {
 				})
 				lightbox_rarrow.onclick = () => {
 					active_slide = (active_slide + 1) % image_list.length
-					lightbox_image.src = image_list[active_slide]
-					active_image.src = image_list[active_slide]
+					lightbox_image.src = image_list[active_slide].path
+					lightbox_caption.textContent = image_list[active_slide].caption
+					active_image.src = image_list[active_slide].path
+					active_caption.textContent = image_list[active_slide].caption
 				}
 
 				// Create the image element for the lightbox
@@ -220,7 +247,13 @@ export default class LiteGallery extends Plugin {
 				})
 				lightbox_image.onerror = function() {
 					this.src='https://raw.githubusercontent.com/jpoles1/obsidian-litegal/eb0e30b2709a3081dd8d32ef4371367b95694881/404notfound.jpg'
-				}						
+				}
+
+				// Create the caption element for the lightbox
+				const lightbox_caption = lightbox.createEl('div', {
+					cls: 'litegal-lightbox-caption',
+					text: image_list[active_slide].caption
+				})						
 
 
 				// Create the exit element for the lightbox and handle click event to close the lightbox

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lightgal",
-	"version": "1.0.0",
+	"version": "1.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lightgal",
-			"version": "1.0.0",
+			"version": "1.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lightgal",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "Easily create carousel galleries to better organize/view images in your Obsidian notes.",
 	"main": "main.js",
 	"scripts": {

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,14 @@
     justify-content: center;
 }
 
+.litegal-caption {
+    text-align: center;
+    padding: 10px;
+    font-size: 14px;
+    color: var(--text-muted);
+    font-style: italic;
+}
+
 .litegal-arrow {
     cursor: pointer;
     font-size: 30px;
@@ -84,6 +92,16 @@
     max-height: 100%;
 }
 
+.litegal-lightbox-caption {
+    text-align: center;
+    padding: 10px;
+    font-size: 16px;
+    color: white;
+    background-color: rgba(0, 0, 0, 0.6);
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+}
+
 .litegal-lightbox-exit {
     position: absolute;
     top: 0;
@@ -107,5 +125,5 @@
     margin: 20px;
     color: #999;
     font-style: italic;
-    
+
 }


### PR DESCRIPTION
Hi,

With this MR I would like to address the https://github.com/jpoles1/obsidian-litegal/issues/1

It adds an option to list images inside the `litegal` tag in a native markdown format - `![Image caption](image/path.jpg)`

Consequently the image title from these native tags then can be used as a caption in the gallery:
<img width="812" height="771" alt="Screenshot 2026-03-17 at 11 13 37" src="https://github.com/user-attachments/assets/665f2438-1824-4549-9a82-5169d6c023e1" />
<img width="766" height="153" alt="Screenshot 2026-03-17 at 11 13 53" src="https://github.com/user-attachments/assets/0ea16523-0b1a-496d-965f-9d0eca926a0f" />

I wanted to keep the changes simple - they don't break the current flow, but they add this functionality with captions and native image tags for those who needs it

Please kindly consider merging this if you find this chages useful or let me know if I need to adjust something

Regards,
Art